### PR TITLE
Add automatic release notes, major tag bump

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - semver-major
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - semver-minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/bump-major.yaml
+++ b/.github/workflows/bump-major.yaml
@@ -1,0 +1,9 @@
+name: Bump major tag
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump:
+    uses: secondlife/update-major-tag-workflow/.github/workflows/update-major-tag.yaml@v1


### PR DESCRIPTION
Improve releases by generating release notes and bumping the major tag (ex, `v1`, `v2`) when new versions are published.

Example: https://github.com/secondlife/action-nfpm/releases

## How do I use this?

1. Approve and merge PRs into the `main` branch. Add `enhanacement` `bug` or `breaking-change` labels to them as specified in release.yaml
2. When a new version is to be published, generate a new release with a cooresponding semver compatible tag (ex: v1.2.0) from the repository release pages, autogenerate notes.
3. Boom, magic. New release v1.2.0 published, v1 tag updated.