### PR TITLE
Fix branch detection for pull request builds.

### DIFF
--- a/which-branch/action.yaml
+++ b/which-branch/action.yaml
@@ -23,6 +23,15 @@ runs:
       id: which-branch
       shell: bash
       run: |
-        branch="$(python '${{ github.action_path }}/which_branch.py' \
-                  -t "${{ inputs.token }}" -r "${{github.repository }}" "${{ github.sha }}")"
+        set -x
+        if [[ "$GITHUB_REF_TYPE" != "tag" ]]
+        then
+            # For a pull request, GITHUB_HEAD_REF is the branch name.
+            # For a branch build, GITHUB_REF_NAME is the branch name.
+            branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+        else
+            # For a tag build, have to discover which branch corresponds.
+            branch="$(python '${{ github.action_path }}/which_branch.py' \
+                      -t "${{ inputs.token }}" -r "${{github.repository }}" "${{ github.sha }}")"
+        fi
         echo "branch=$branch" >> "$GITHUB_OUTPUT"

--- a/which-branch/action.yaml
+++ b/which-branch/action.yaml
@@ -15,10 +15,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install Python dependencies
-      shell: bash
-      run: pip3 install PyGithub
-
     - name: Determine which branch
       id: which-branch
       shell: bash
@@ -31,6 +27,7 @@ runs:
             branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
         else
             # For a tag build, have to discover which branch corresponds.
+            pip3 install PyGithub
             branch="$(python '${{ github.action_path }}/which_branch.py' \
                       -t "${{ inputs.token }}" -r "${{github.repository }}" "${{ github.sha }}")"
         fi


### PR DESCRIPTION
The build for a PR involves a new temporary merge commit, which confuses the `which_branch.py` script because the temporary merge commit is not the tip of _any_ named branch. That said, for a PR build, GitHub sets `GITHUB_HEAD_REF` to the pull request source branch, so we don't even need to consult `which_branch.py`.

Also, only install Python dependencies when we must actually run our Python script.