### PR TITLE
Update to BugSplat-Git/symbol-upload@v7.2.3 to fix upload failures.

### DIFF
--- a/post-bugsplat-mac/action.yaml
+++ b/post-bugsplat-mac/action.yaml
@@ -34,7 +34,7 @@ runs:
         path: _artifacts
 
     - name: Post to BugSplat
-      uses: BugSplat-Git/symbol-upload@v7.0.1
+      uses: BugSplat-Git/symbol-upload@v7.2.3
       with:
         username: "${{ inputs.username }}"
         password: "${{ inputs.password }}"

--- a/post-bugsplat-windows/action.yaml
+++ b/post-bugsplat-windows/action.yaml
@@ -46,7 +46,7 @@ runs:
         tar -xjf secondlife-symbols-windows-64.tar.bz2
 
     - name: Post to BugSplat
-      uses: BugSplat-Git/symbol-upload@v7.0.1
+      uses: BugSplat-Git/symbol-upload@v7.2.3
       with:
         username: "${{ inputs.username }}"
         password: "${{ inputs.password }}"


### PR DESCRIPTION
e.g. https://github.com/secondlife/viewer/actions/runs/7848814161