### PR TITLE
Switch to download-artifact@v4, xz compression

### DIFF
--- a/post-bugsplat-mac/action.yaml
+++ b/post-bugsplat-mac/action.yaml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Download viewer symbols
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: macOS-symbols
         path: _artifacts

--- a/post-bugsplat-windows/action.yaml
+++ b/post-bugsplat-windows/action.yaml
@@ -28,13 +28,13 @@ runs:
   using: composite
   steps:
     - name: Download viewer exe
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Windows-app
         path: _artifacts
 
     - name: Download viewer symbols
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Windows-symbols
         path: _artifacts
@@ -43,7 +43,7 @@ runs:
       shell: bash
       run: |
         cd _artifacts
-        tar -xjf secondlife-symbols-windows-64.tar.bz2
+        tar -xJf secondlife-symbols-windows-64.tar.xz
 
     - name: Post to BugSplat
       uses: BugSplat-Git/symbol-upload@v7.2.3

--- a/sign-pkg-mac/action.yaml
+++ b/sign-pkg-mac/action.yaml
@@ -45,7 +45,7 @@ runs:
   using: composite
   steps:
     - name: Fetch Mac app
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: macOS-app
         path: .tarball
@@ -56,7 +56,7 @@ runs:
       run: |
         set -x
         mkdir -p ".app"
-        tar xjf .tarball/* -C ".app"
+        tar xJf .tarball/* -C ".app"
 
     - name: Set up the app sparseimage
       shell: bash
@@ -172,7 +172,7 @@ runs:
         rm "${{ env.sparsename }}"
 
     - name: Post the installer
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: "macOS-installer"
         path: ${{ env.installer }}

--- a/sign-pkg-windows/action.yaml
+++ b/sign-pkg-windows/action.yaml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Fetch Windows app
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: Windows-app
         path: .app
@@ -101,7 +101,7 @@ runs:
                "$installer"
 
     - name: Post the installer
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: "Windows-installer"
         path: ${{ env.installer }}


### PR DESCRIPTION
Two breaking changes

- Upgrade to actions/download-artifact@v4 ([Blost post](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/))
- Switch from using bz2 to xz compression with artifacts

Adopting this change will mandate a major version bump (v1 to v2) and a corresponding change to secondlife/viewer. (https://github.com/secondlife/viewer/pull/1198)