### PR TITLE
Update to BugSplat's symbol-upload@v9.1.1

### DIFF
--- a/post-bugsplat-mac/action.yaml
+++ b/post-bugsplat-mac/action.yaml
@@ -34,7 +34,7 @@ runs:
         path: _artifacts
 
     - name: Post to BugSplat
-      uses: BugSplat-Git/symbol-upload@v7.2.3
+      uses: BugSplat-Git/symbol-upload@v9.1.1
       with:
         username: "${{ inputs.username }}"
         password: "${{ inputs.password }}"

--- a/post-bugsplat-windows/action.yaml
+++ b/post-bugsplat-windows/action.yaml
@@ -46,7 +46,7 @@ runs:
         tar -xJf secondlife-symbols-windows-64.tar.xz
 
     - name: Post to BugSplat
-      uses: BugSplat-Git/symbol-upload@v7.2.3
+      uses: BugSplat-Git/symbol-upload@v9.1.1
       with:
         username: "${{ inputs.username }}"
         password: "${{ inputs.password }}"


### PR DESCRIPTION
Merging this to main and creating a new viewer-build-util release should allow all viewer builds to pick up the change without needing to update every project's `.github/workflows/build.yaml`.