### PR TITLE
AzureSignTool emits no cert expiration date. Don't look for it.

### DIFF
--- a/sign-pkg-windows/sign.py
+++ b/sign-pkg-windows/sign.py
@@ -13,7 +13,6 @@ $/LicenseInfo$
 import shlex
 import subprocess
 import sys
-from datetime import datetime, timedelta
 from pathlib import Path
 
 from pyng.commands import Commands

--- a/sign-pkg-windows/sign.py
+++ b/sign-pkg-windows/sign.py
@@ -10,7 +10,6 @@ Copyright (c) 2023, Linden Research, Inc.
 $/LicenseInfo$
 """
 
-import re
 import shlex
 import subprocess
 import sys
@@ -23,10 +22,6 @@ from pyng.commands import Commands
 class Error(Exception):
     pass
 
-
-ExpiresLine = re.compile(
-    r"\bExpires:\s+\S{3}\s+(\S{3}) (\d+) \d\d:\d\d:\d\d (\d{4})"
-)  # looking for a date like 'Sep 16 23:59:59 2017'
 
 # Make a function decorator that will generate an ArgumentParser
 command = Commands()
@@ -60,34 +55,12 @@ def sign(executable, *, vault_uri, cert_name, client_id, client_secret, tenant_i
                '-tr', 'http://timestamp.digicert.com',
                '-v', executable]
     print(name, 'signing:', shlex.join(command))
-    done = subprocess.run(command,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT,
-                          text=True)
-    print(done.stdout, end='')
+    done = subprocess.run(command)
     rc = done.returncode
     if rc != 0:
         raise Error(name + ' signing failed')
 
     print(name, 'signing succeeded')
-    # Check the certificate expiration date in the output to warn of imminent expiration
-    for line in done.stdout.splitlines():
-        found = ExpiresLine.search(line)
-        if found:
-            # month is an abbreviated name, translate
-            try:
-                expiration = datetime.strptime(' '.join(found.groups()), '%b %d %Y')
-            except ValueError:
-                raise Error('failed to parse expiration from: ' + line)
-            else:
-                expires = expiration - datetime.now()
-                print(f'Certificate expires in {expires.days} days')
-                if expires < timedelta(certwarning):
-                    print(f'::warning::Certificate expires in {expires.days} days: {expiration}')
-                break
-    else:
-        # raise Error('Failed to find certificate expiration date')
-        print('::warning::Failed to find certificate expiration date')
     return rc
 
 


### PR DESCRIPTION
The sign.py logic that looks for a cert expiration date in the signing output, and warns if it doesn't find it, dates back to the old signing tool. Since the new AzureSignTool doesn't produce that output, every build since the changeover has been spamming the build output with warnings about not finding the cert expration date.